### PR TITLE
Fix typo

### DIFF
--- a/source/_posts/2018-08-14-shasum.md
+++ b/source/_posts/2018-08-14-shasum.md
@@ -16,7 +16,7 @@ tags:
 
 기본적으로는 `sha1` 알고리즘으로 읽도록 되어 있으나 `-a` 플래그를 사용해서 224, 256, 384, 512, 512224, 512256 알고리즘을 지원합니다. Transmission 같은 경우는 256 알고리즘 해시값을 공개해두었군요.
 
-![shasum_transmission_256](/image/2018-08-14-shasum/shasum_transmission_256.png)
+![shasum_transmission_256](/images/2018-08-14-shasum/shasum_transmission_256.png)
 
 배포자가 해시값을 공개해두지 않았다면 어쩔 수 없지만 공개해두었다면 실행하기 전에 비교하는 습관을 들이는 것도 나쁘지는 않습니다. 귀찮더라도 설치할 때 한 번 정도는 말이죠.
 


### PR DESCRIPTION
typo in post `shasum`; image link was broken